### PR TITLE
MoneyField for representing amounts in events & commands.

### DIFF
--- a/fyndiq_helpers/message_fields.py
+++ b/fyndiq_helpers/message_fields.py
@@ -1,0 +1,22 @@
+
+from typing import NamedTumple
+
+
+class MoneyField(NamedTuple):
+    """
+    Represents the composite amount field for money values.
+    Used by both events and commands.
+    Avro will serialize it as follows:
+    >>> {'amount': 1000, 'currency': 'SEK'}
+
+    Examples:
+        >>> from typing import Dict, NamedTuple
+        >>> from eventsourcing_helpers.message import Event
+        >>>
+        >>> @Event
+        >>> class CheckoutStarted(NamedTuple):
+        >>>     total_amount = Dict[str, MoneyField]
+
+    """
+    amount: int
+    currency: str


### PR DESCRIPTION
This is `MoneyField` that can be used to serialize all money values in events and commands.

Please use it like this:
```python
       from typing import Dict, NamedTuple
       from eventsourcing_helpers.message import Event

        @Event
        class CheckoutStarted(NamedTuple):
            total_amount = Dict[str, MoneyField]
```