### PR TITLE
Allow unknown fields in the validator

### DIFF
--- a/fyndiq_helpers/decorators.py
+++ b/fyndiq_helpers/decorators.py
@@ -47,7 +47,7 @@ class validate_payload:
     """
 
     def __init__(self, schema: dict,
-                 allow_unknown_fields: bool = True) -> None:
+                 allow_unknown_fields: bool = False) -> None:
         self.schema = schema
         self.allow_unknown_fields = allow_unknown_fields
 

--- a/fyndiq_helpers/decorators.py
+++ b/fyndiq_helpers/decorators.py
@@ -46,14 +46,19 @@ class validate_payload:
     The validation is done by Cerberus lib against view-specific schemas.
     """
 
-    def __init__(self, schema: dict) -> None:
+    def __init__(self, schema: dict,
+                 allow_unknown_fields: bool = True) -> None:
         self.schema = schema
+        self.allow_unknown_fields = allow_unknown_fields
 
     def __call__(self, view: Callable) -> Callable:
         @wraps(view)
         def wrapped_function(request, *args, **kwargs) -> Any:
             payload = request.json or {}
-            validator = cerberus.Validator(self.schema)
+            validator = cerberus.Validator(
+                self.schema,
+                allow_unknown=self.allow_unknown_fields
+            )
             if not validator.validate(payload):
                 errors = validator.errors
                 description = "Invalid payload"

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -45,6 +45,25 @@ class TestViewDecorators:
                          b':{"code":400,"message":{"field":["must be of string type"]}}}'  # noqa
         assert request_response.body == expected_error
 
+    def test_validate_payload_ignore_extra_fields(self):
+        self.mocked_request.json = {
+            'field': 'aaaaa',
+            'extra_field': 33333,
+            'another_extra': 66666,
+        }
+
+        schema = {
+            'field': {'type': 'string'}
+        }
+
+        @validate_payload(schema, allow_unknown_fields=True)
+        def view(request, payload):
+            return response.json({}, status=200)
+
+        request_response = view(self.mocked_request)
+
+        assert request_response.status == 200
+
     def test_check_required_params_success(self):
         self.mocked_request.args = {"required_param": "value"}
 

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -45,11 +45,10 @@ class TestViewDecorators:
                          b':{"code":400,"message":{"field":["must be of string type"]}}}'  # noqa
         assert request_response.body == expected_error
 
-    def test_validate_payload_ignore_extra_fields(self):
+    def test_validate_payload_should_ignore_extra_fields(self):
         self.mocked_request.json = {
             'field': 'aaaaa',
             'extra_field': 33333,
-            'another_extra': 66666,
         }
 
         schema = {
@@ -63,6 +62,28 @@ class TestViewDecorators:
         request_response = view(self.mocked_request)
 
         assert request_response.status == 200
+
+    def test_validate_payload_ignore_should_complain_about_fields(self):
+        self.mocked_request.json = {
+            'field': 'aaaaa',
+            'extra_field': 33333,
+        }
+
+        schema = {
+            'field': {'type': 'string'}
+        }
+
+        @validate_payload(schema)
+        def view(request, payload):
+            return response.json({}, status=200)
+
+        request_response = view(self.mocked_request)
+
+        assert request_response.status == 400
+        expected_error = b'{"description":"Invalid payload","content"' \
+                         b':{"code":400,"message":{"extra_field":["unknown field"]}}}'  # noqa
+        print(request_response.body)
+        assert request_response.body == expected_error
 
     def test_check_required_params_success(self):
         self.mocked_request.args = {"required_param": "value"}


### PR DESCRIPTION
When you use the validate_payload decorator, you should be able to ignore extra fields, when you don't need to validate them. 
```
@validate_payload(schema, allow_unknown_fields=True)
```