### PR TITLE
Validation of the content type.

### DIFF
--- a/fyndiq_helpers.egg-info/PKG-INFO
+++ b/fyndiq_helpers.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 1.0
 Name: fyndiq_helpers
-Version: 0.1.0
+Version: 0.1.3
 Summary: Helpers for fyndiq services
 Home-page: https://github.com/fyndiq/fyndiq_helpers
 Author: Fyndiq AB

--- a/fyndiq_helpers/decorators.py
+++ b/fyndiq_helpers/decorators.py
@@ -54,6 +54,19 @@ class validate_payload:
     def __call__(self, view: Callable) -> Callable:
         @wraps(view)
         def wrapped_function(request, *args, **kwargs) -> Any:
+
+            if request.content_type != 'application/json':
+                return response.json(
+                    {
+                        'description': 'Unsupported Media Type',
+                        'content': {
+                            'code': 415,
+                            'message': 'Expected application/json'
+                        }
+                    },
+                    415
+                )
+
             payload = request.json or {}
             validator = cerberus.Validator(
                 self.schema,
@@ -61,7 +74,7 @@ class validate_payload:
             )
             if not validator.validate(payload):
                 errors = validator.errors
-                description = "Invalid payload"
+                description = 'Invalid payload'
                 logger.warning(description, payload=payload, errors=errors)
                 desc = {
                     'description': description,
@@ -95,7 +108,7 @@ class in_state:
             if instance.state in self.allowed_states:
                 return function(*args, **kwargs)
             logger.warning(
-                "Invalid aggregate state", method=function.__name__,
+                'Invalid aggregate state', method=function.__name__,
                 current_state=instance.state,
                 allowed_states=[state for state in self.allowed_states]
             )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="fyndiq_helpers",
-    version="0.1.0",
+    version="0.1.3",
     description="Helpers for fyndiq services",
     url="https://github.com/fyndiq/fyndiq_helpers",
     author="Fyndiq AB",


### PR DESCRIPTION
`validate_payload` decorator will now check if the payload is `application/json`