### PR TITLE
Suppress datadog errors

### DIFF
--- a/fyndiq_helpers/log_config.py
+++ b/fyndiq_helpers/log_config.py
@@ -75,6 +75,11 @@ def setup(use_colors: bool, use_logstash: bool, use_filters: bool):
                 'handlers': ['console'],
                 'level': 'INFO',
                 'propagate': False
+            },
+            'datadog': {
+                'handlers': ['console'],
+                'level': 'ERROR',
+                'propagate': False,
             }
         }
     })


### PR DESCRIPTION
We get automatic uploads of metrics to datadog from the eventsourcing_helpers library.
When running this locally we have no datadog agent running, and therefore we get flooded with error messages.
This PR is supposed to remove those messages!