### PR TITLE
Support Content-Type parameters

### DIFF
--- a/fyndiq_helpers/decorators.py
+++ b/fyndiq_helpers/decorators.py
@@ -55,7 +55,7 @@ class validate_payload:
         @wraps(view)
         def wrapped_function(request, *args, **kwargs) -> Any:
 
-            if request.content_type != 'application/json':
+            if 'application/json' not in request.content_type:
                 return response.json(
                     {
                         'description': 'Unsupported Media Type',

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -28,6 +28,22 @@ class TestViewDecorators:
 
         assert request_response.status == 200
 
+    def test_validate_content_type_with_parameters(self):
+        self.mocked_request.content_type = 'application/json; charset=UTF8'
+        self.mocked_request.json = {"field": "value"}
+
+        schema = {
+            'field': {'type': 'string'}
+        }
+
+        @validate_payload(schema)
+        def view(request, payload):
+            return response.json({}, status=200)
+
+        request_response = view(self.mocked_request)
+
+        assert request_response.status == 200
+
     def test_validate_payload_incorrect_content_type(self):
         self.mocked_request.content_type = 'application/octet-stream'
         self.mocked_request.json = {"field": 12345}


### PR DESCRIPTION
Android always send `Content-Type: application/json; charset=UTF-8`, so right now some APIs will return 415.